### PR TITLE
6.5. profile page & edit view for personal data

### DIFF
--- a/public/stylesheets/profile.css
+++ b/public/stylesheets/profile.css
@@ -1,7 +1,27 @@
-.profile-buttons {
-    margin-top: 20px;
-    align-items: flex-end;
+@media only screen and (min-width: 450px) {
+    .profile-buttons {
+        margin-top: 20px;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+    }
 }
+
+@media only screen and (max-width: 450px) {
+    .profile-buttons {
+        margin: 20px 10px;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .profile-buttons button{
+        margin-top: 5px;
+    }
+}
+
 
 .message-btn {
     margin-top: 40px;
@@ -19,4 +39,18 @@
 .personal-info {
     margin-bottom: 30px;
     text-align: center;
+    background-color:  #9AB3F5 !important;
+    padding: 10px 0px;
+    border-radius: 20px;
+    color: #f8f9fa !important;
+}
+
+.tag {
+    background-color: #9ab3f5 !important;
+    padding: 7px !important;
+}
+
+.color-cancel {
+    background-color: #f8f9fa !important;
+    color: #9AB3F5 !important;
 }

--- a/public/stylesheets/profile.css
+++ b/public/stylesheets/profile.css
@@ -1,0 +1,22 @@
+.profile-buttons {
+    margin-top: 20px;
+    align-items: flex-end;
+}
+
+.message-btn {
+    margin-top: 40px;
+}
+
+.edit-form {
+    margin-left: 20px;
+}
+
+#edit-container {
+    text-align: left !important;
+    justify-content: center !important;
+}
+
+.personal-info {
+    margin-bottom: 30px;
+    text-align: center;
+}

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -25,6 +25,7 @@
   <%# our custom style sheets - link here to overwrite bootstrap %>
    <link href="/stylesheets/styles.css" rel="stylesheet" type="text/css">
    <link href="/stylesheets/matches.css" rel="stylesheet" type="text/css">
+   <link href="/stylesheets/profile.css" rel="stylesheet" type="text/css">
    <link rel="stylesheet" href="/stylesheets/indexPage.css">
 
  </head>

--- a/views/matches/candidates/show.ejs
+++ b/views/matches/candidates/show.ejs
@@ -1,15 +1,7 @@
 <div class="container">
   <div class="main-body">
 
-    <!-- Breadcrumb -->
-    <nav aria-label="breadcrumb" class="main-breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/">Home</a></li>
-        <li class="breadcrumb-item"><a href="/matches">Matches</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Candidate info</li>
-      </ol>
-    </nav>
-    <!-- /Breadcrumb -->
+    <%- include('../../partials/matches/nav.ejs') %>
 
     <div class="row gutters-sm">
       <!-- Left column -->
@@ -23,7 +15,7 @@
                 <p class="text-secondary mb-1">Full Stack Developer</p>
                 <!-- Here we will insert the current location. -->
                 <p class="text-muted font-size-sm">Bay Area, San Francisco, CA</p>
-                <button class="btn btn-outline-primary">Message</button>
+                <%- include('../../partials/matches/connect.ejs') %>
               </div>
             </div>
           </div>

--- a/views/partials/matches/connect.ejs
+++ b/views/partials/matches/connect.ejs
@@ -1,0 +1,3 @@
+<div class="message-btn">
+    <button class="btn btn-outline-primary">Message</button>
+</div>

--- a/views/partials/matches/nav.ejs
+++ b/views/partials/matches/nav.ejs
@@ -1,0 +1,10 @@
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb" class="main-breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="/">Home</a></li>
+          <li class="breadcrumb-item"><a href="/matches">Matches</a></li>
+          <!-- Naming has to be adapted for recruiter and candidate roles - Candidate info or Job info-->
+          <li class="breadcrumb-item active" aria-current="page">Candidate info</li>
+        </ol>
+      </nav>
+      <!-- /Breadcrumb -->

--- a/views/user/edit.ejs
+++ b/views/user/edit.ejs
@@ -5,37 +5,41 @@
   <hr>
   <div class="row" id="edit-container">
     <div class="col-md-9">
-      <h3 class="personal-info">Personal info</h3>
+      <h3 class="personal-info">Edit personal info</h3>
 
-      <form class="edit-form">
+      <form class="edit-form" action="<%=`/user/${user._id}/update?_method=PUT`%>" method="post">
         <div class="form-group row">
           <label for="inputEmail" class="col-sm-2 col-form-label edit-container">First name</label>
           <div class="col-sm-10">
-            <input type="text" class="form-control" id="inputEmail" placeholder="First name">
+            <input type="text" class="form-control" name="firstname" value="<%= user.name.firstname %>">
           </div>
         </div>
         <div class="form-group row">
           <label for="inputEmail" class="col-sm-2 col-form-label edit-container">Last name</label>
           <div class="col-sm-10">
-            <input type="text" class="form-control" id="inputEmail" placeholder="Last name">
+            <input type="text" class="form-control" name="lastname" value="<%= user.name.lastname %>">
           </div>
         </div>
         <div class="form-group row">
           <label for="inputEmail" class="col-sm-2 col-form-label edit-container">Email</label>
           <div class="col-sm-10">
-            <input type="email" class="form-control" id="inputEmail" placeholder="Email">
+            <input type="email" class="form-control" name="email" value="<%= user.email %>">
           </div>
         </div>
         <div class="form-group row">
           <label for="inputPassword" class="col-sm-2 col-form-label edit-container">Password</label>
           <div class="col-sm-10">
-            <input type="password" class="form-control" id="inputPassword" placeholder="Password">
+            <input type="password" class="form-control" name="password" value="<%= user.password%>">
           </div>
         </div>
         <div class="form-group row">
           <div class="col-sm-10 offset-sm-2">
-            <input type="submit" class="btn btn-primary" value="Save Changes">
-            <input type="reset" class="btn btn-light" value="Cancel">
+              <input type="submit" class="btn btn-primary" value="Save Changes">
+              <input type="reset" class="btn btn-primary color-cancel" value="Cancel">
+              <a href="<%=`/user/${user._id}` %>">
+                <input class="btn btn-primary color-cancel profile-buttons" value="<< Back"></button>
+               </a>
+              
           </div>
         </div>
       </form>

--- a/views/user/edit.ejs
+++ b/views/user/edit.ejs
@@ -1,15 +1,41 @@
-<form action="<%=`/user/${user._id}/update?_method=PUT`%>" method="post">
-  <h2>Edit information:</h2>
-  <label>First Name: </label>
-  <input type="text" name="firstname" value="<%= user.name.firstname %>" autofocus>
-  <label>Last Name: </label>
-  <input type="text" name="lastname" value="<%= user.name.lastname %>">
-  <label>E-Mail: </label>
-  <input type="email" name="email" value="<%= user.email %>">
-  <label>Password:</label>
-  <input type="password" name="password" value="<%= user.password %>">
-  <button type="submit">Update</button>
-</form>
 <!-- do not delete it completely in case we need an admin in the end.
 <button class="delete_user" onclick="location.href='/user/<%= user.id %>/delete?_method=DELETE'">Delete</button>
--->
+ -->
+<div class="container">
+  <hr>
+  <div class="row" id="edit-container">
+    <div class="col-md-9">
+      <h3 class="personal-info">Personal info</h3>
+
+      <form class="edit-form">
+        <div class="form-group row">
+          <label for="inputEmail" class="col-sm-2 col-form-label edit-container">First name</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="inputEmail" placeholder="First name">
+          </div>
+        </div>
+        <div class="form-group row">
+          <label for="inputEmail" class="col-sm-2 col-form-label edit-container">Last name</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="inputEmail" placeholder="Last name">
+          </div>
+        </div>
+        <div class="form-group row">
+          <label for="inputEmail" class="col-sm-2 col-form-label edit-container">Email</label>
+          <div class="col-sm-10">
+            <input type="email" class="form-control" id="inputEmail" placeholder="Email">
+          </div>
+        </div>
+        <div class="form-group row">
+          <label for="inputPassword" class="col-sm-2 col-form-label edit-container">Password</label>
+          <div class="col-sm-10">
+            <input type="password" class="form-control" id="inputPassword" placeholder="Password">
+          </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-10 offset-sm-2">
+            <input type="submit" class="btn btn-primary" value="Save Changes">
+            <input type="reset" class="btn btn-light" value="Cancel">
+          </div>
+        </div>
+      </form>

--- a/views/user/profile.ejs
+++ b/views/user/profile.ejs
@@ -1,16 +1,7 @@
 <div class="container">
     <div class="main-body">
-
-        <!-- Breadcrumb -->
-        <nav aria-label="breadcrumb" class="main-breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="/">Home</a></li>
-                <li class="breadcrumb-item"><a href="/matches">Matches</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Candidate info</li>
-            </ol>
-        </nav>
-        <!-- /Breadcrumb -->
-
+        <hr>
+        <h1 class="personal-info">Personal profile</h1>
         <div class="row gutters-sm">
             <!-- Left column -->
             <div class="col-md-4 mb-3">
@@ -19,18 +10,14 @@
                         <div class="d-flex flex-column align-items-center text-center">
 
                             <div class="mt-3">
-                                <h4>
+                                <h2>
                                     <%= user.fullName %>
-                                </h4>
+                                </h2>
                                 <% if (user.role==='candidate' && user.candidateProfile) { %>
                                     <p class="text-secondary mb-1">Full Stack Developer</p>
                                     <!-- Here we will insert the current location. -->
                                     <p class="text-muted font-size-sm">Bay Area, San Francisco, CA</p>
                                     <% } %>
-                                        <div class="message-btn">
-                                            <button class="btn btn-outline-primary">Message</button>
-                                        </div>
-
                             </div>
                         </div>
                     </div>
@@ -119,7 +106,7 @@
                                 <div class="card-body">
                                     <% candidate.work_culture_preferences.forEach ( preference => { %>
                                     <div>
-                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1">
+                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1 tag">
                                             <%= preference %>
                                         </a>
                                     </div>
@@ -136,7 +123,7 @@
                                 <div class="card-body">
                                     <% candidate.hard_skills.forEach ( skill => { %>
                                     <div>
-                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1">
+                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1 tag">
                                             <%= skill%>
                                         </a>
                                     </div>
@@ -154,7 +141,7 @@
                                 <div class="card-body">
                                     <% candidate.soft_skills.forEach ( skill => { %>
                                     <div>
-                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1">
+                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1 tag">
                                             <%= skill %>
                                         </a>
                                     </div>

--- a/views/user/profile.ejs
+++ b/views/user/profile.ejs
@@ -1,35 +1,230 @@
-<!DOCTYPE html>
-<html>
+<div class="container">
+    <div class="main-body">
 
-<head>
-    <meta charset="utf-8">
-    <title>User Profile</title>
-</head>
+        <!-- Breadcrumb -->
+        <nav aria-label="breadcrumb" class="main-breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="/">Home</a></li>
+                <li class="breadcrumb-item"><a href="/matches">Matches</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Candidate info</li>
+            </ol>
+        </nav>
+        <!-- /Breadcrumb -->
 
-<body class="body">
-    <h1>User Profile</h1>
-    <div>
-        <div>
-            <ul>
-                <b>First Name:</b> <%= user.name.firstname%> <br>
-                <b>Last Name:</b> <%= user.name.lastname%> <br>
-                <b>E-Mail:</b> <%= user.email %> <br>
+        <div class="row gutters-sm">
+            <!-- Left column -->
+            <div class="col-md-4 mb-3">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="d-flex flex-column align-items-center text-center">
+
+                            <div class="mt-3">
+                                <h4>
+                                    <%= user.fullName %>
+                                </h4>
+                                <% if (user.role==='candidate' && user.candidateProfile) { %>
+                                    <p class="text-secondary mb-1">Full Stack Developer</p>
+                                    <!-- Here we will insert the current location. -->
+                                    <p class="text-muted font-size-sm">Bay Area, San Francisco, CA</p>
+                                    <% } %>
+                                        <div class="message-btn">
+                                            <button class="btn btn-outline-primary">Message</button>
+                                        </div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="card mt-3">
+                    <ul class="list-group list-group-flush">
+                        <li class="list-group-item d-flex justify-content-between align-items-center flex-wrap">
+                            <h6 class="mb-0"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                    viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                                    stroke-linecap="round" stroke-linejoin="round"
+                                    class="feather feather-globe mr-2 icon-inline">
+                                    <circle cx="12" cy="12" r="10"></circle>
+                                    <line x1="2" y1="12" x2="22" y2="12"></line>
+                                    <path
+                                        d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z">
+                                    </path>
+                                </svg>Email</h6>
+                            <span class="text-secondary">
+                                <%= user.email %>
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <!-- Right column -->
+            <div class="col-md-8">
                 <% if (user.candidateProfile) { %>
-                    <b>Preferred position:</b> <%= candidate.preferred_position %> <br>
-                    <b>Work culture preferences:</b> <%= candidate.work_culture_preferences %> <br>
-                    <b>Other aspects:</b> <%= candidate.other_aspects %> <br>
-                <% } %> 
-                <a href="<%=`/user/${user._id}/edit` %>">
-                    <button class="edit">Edit Personal Data</button>
-                </a>
-                <% if (user.candidateProfile) { %>
-                    <a href="<%=`/candidates/${user.candidateProfile._id}/edit` %>">
-                        <button class="edit">Edit Candidate Profile</button>
-                    </a>
-                <% } %> 
-            </ul>
+                    <!-- Candidate view -->
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <h6 class="mb-0">
+                                        Preferred position
+                                    </h6>
+                                </div>
+                                <div class="col-sm-9 text-secondary">
+                                    <%= candidate.preferred_position %>
+                                </div>
+                            </div>
+                            <hr>
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <h6 class="mb-0">
+                                        Expected salary
+                                    </h6>
+                                </div>
+                                <div class="col-sm-9 text-secondary">
+                                    <%= candidate.expected_salary %>
+                                </div>
+                            </div>
+                            <hr>
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <h6 class="mb-0">
+                                        Employment type
+                                    </h6>
+                                </div>
+                                <div class="col-sm-9 text-secondary">
+                                    <%= candidate.job_type %>
+                                </div>
+                            </div>
+                            <hr>
+                            <div class="row">
+                                <div class="col-sm-3">
+
+                                    <h6 class="mb-0">
+                                        Preferred location
+                                    </h6>
+                                </div>
+                                <div class="col-sm-9 text-secondary">
+                                    <%= candidate.preferred_location %>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <h6 class="mb-0">
+                                        Work culture
+                                    </h6>
+                                </div>
+                                <div class="card-body">
+                                    <% candidate.work_culture_preferences.forEach ( preference => { %>
+                                    <div>
+                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1">
+                                            <%= preference %>
+                                        </a>
+                                    </div>
+                                    <% }); %>
+                                </div>
+                            </div>
+                            <hr>
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <h6 class="mb-0">
+                                        Hard skills
+                                    </h6>
+                                </div>
+                                <div class="card-body">
+                                    <% candidate.hard_skills.forEach ( skill => { %>
+                                    <div>
+                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1">
+                                            <%= skill%>
+                                        </a>
+                                    </div>
+                                    <% }); %>
+                                </div>
+                            </div>
+                            <hr>
+
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <h6 class="mb-0">
+                                        Soft skills
+                                    </h6>
+                                </div>
+                                <div class="card-body">
+                                    <% candidate.soft_skills.forEach ( skill => { %>
+                                    <div>
+                                        <a href="#" class="badge badge-pill badge-primary mr-1 my-1">
+                                            <%= skill %>
+                                        </a>
+                                    </div>
+                                    <% }); %>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row gutters-sm">
+                        <div id="questionnaire">
+                            <div class="card h-100">
+                                <div class="card-body">
+                                    <h6 class="d-flex align-items-center mb-3">Work experience</h6>
+                                    <p>
+                                        <%= candidate.work_experience %>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <% } else {%>
+                        <!-- Recruiter view -->
+                        <div class="card mb-3">
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-sm-3">
+                                        <h6 class="mb-0">
+                                            First name
+                                        </h6>
+                                    </div>
+                                    <div class="col-sm-9 text-secondary">
+                                        <%= user.name.firstname%>
+                                    </div>
+                                </div>
+                                <hr>
+                                <div class="row">
+                                    <div class="col-sm-3">
+                                        <h6 class="mb-0">
+                                            Last name
+                                        </h6>
+                                    </div>
+                                    <div class="col-sm-9 text-secondary">
+                                        <%= user.name.lastname%>
+                                    </div>
+                                </div>
+                                <hr>
+                                <div class="row">
+                                    <div class="col-sm-3">
+                                        <h6 class="mb-0">
+                                            Email
+                                        </h6>
+                                    </div>
+                                    <div class="col-sm-9 text-secondary">
+                                        <%= user.email %>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <% } %>
+                            <div class="profile-buttons">
+                                <a href="<%=`/user/${user._id}/edit` %>">
+                                    <button class="btn btn-primary">Edit Personal Data</button>
+                                </a>
+                                <% if (user.candidateProfile) { %>
+                                    <a href="<%=`/candidates/${user.candidateProfile._id}/edit` %>">
+                                        <button class="btn btn-primary">Edit Candidate Profile</button>
+                                    </a>
+                                    <% } %>
+                            </div>
+            </div>
         </div>
     </div>
-</body>
-
-</html>
+</div>


### PR DESCRIPTION
- Profile page with different outlook for candidate and recruiter
-  Only candidate has the candidate profile data on its profile page. Recruiter does not have it of course.
- Edit view for personal data is added with 3 buttons (Save changes, Cancel, Back - to redirect back to profile page)
- Do not forget that changing of the password does not work.
- Yes, individual match and profile page look almost same but we do not have to delete one of them, just have to put some stuff in partials to reuse smth on match page and smth on profile page. - probably not relevant already
- Color of tags changed to our default one.
- Also as you see I left emails on left side and right side otherwise it looks so empty...

![image](https://user-images.githubusercontent.com/38938392/102714377-68919680-42ce-11eb-97ab-9c4bbf4172c2.png)

![image](https://user-images.githubusercontent.com/38938392/102714336-2405fb00-42ce-11eb-924f-e6b9cb168abf.png)
**Candidate:** 
![image](https://user-images.githubusercontent.com/38938392/102809564-817b7400-43c2-11eb-83de-e315cd6d8130.png)
